### PR TITLE
Raise the Argo CD controller memory limit

### DIFF
--- a/environments/argocd-with-tanka/main.jsonnet
+++ b/environments/argocd-with-tanka/main.jsonnet
@@ -155,6 +155,18 @@ local cluster = {
                 'policy.csv': std.join('', ['g, %s, role:admin\n' % x for x in cluster.github_teams]),
               },
             },
+            controller: {
+              resources: {
+                requests: {
+                  cpu: '250m',
+                  memory: '256Mi',
+                },
+                limits: {
+                  cpu: '1',
+                  memory: '1Gi',
+                },
+              },
+            },
             repoServer: {
               existingVolumes: {
                 ramdisk(capacity):: { emptyDir: { medium: 'Memory', sizeLimit: capacity } },


### PR DESCRIPTION
We're hitting OOM problems at the default 512Mi, so raise the limit to 1Gi. This may cause quota contention in vclusters that are very close their the maximum limit sum.